### PR TITLE
Pass fixture scope as a keyword argument

### DIFF
--- a/pytest_gc/plugin.py
+++ b/pytest_gc/plugin.py
@@ -9,14 +9,14 @@ default_scope = six.get_function_defaults(pytest.fixture)[0]
 scope = os.environ.get("gc_scope", default_scope)
 
 
-@pytest.fixture(scope, autouse=True)
+@pytest.fixture(scope=scope, autouse=True)
 def switch(request):
     if request.config.getoption("gc_disable"):
         request.addfinalizer(gc.enable)
         gc.disable()
 
 
-@pytest.fixture(scope, autouse=True)
+@pytest.fixture(scope=scope, autouse=True)
 def change_threshold(request):
     threshold = request.config.getoption("gc_threshold")
     if threshold:


### PR DESCRIPTION
Update fixture dectorators according to the changes in https://github.com/pytest-dev/pytest/pull/5776

Fixes warnings like
```
pytest/5.3.1/lib/python3.6/site-packages/_pytest/fixtures.py:1138: PytestDeprecationWarning: Passing arguments to pytest.fixture() as positional arguments is deprecated - pass them as a keyword argument instead.
  name=name
```